### PR TITLE
Add leads pages

### DIFF
--- a/src/app/plataform/leads/[id]/page.tsx
+++ b/src/app/plataform/leads/[id]/page.tsx
@@ -1,0 +1,55 @@
+'use client'
+
+// Dependencies
+import { useParams } from 'next/navigation'
+import { useQuery } from 'react-query'
+
+// Components
+import Skeleton from '@/components/catalyst/skeleton'
+import { DescriptionList, DescriptionTerm, DescriptionDetails } from '@/components/catalyst/description-list'
+
+// Services
+import { GetLead } from '@/services/leads'
+
+// Types
+import type { Lead } from '@/services/leads/leads.props'
+
+const LeadDetailPage = () => {
+  const params = useParams()
+  const id = params?.id as string
+
+  const { data, isFetching } = useQuery<Lead>(['lead', id], () => GetLead(id), { enabled: !!id })
+
+  if (isFetching) return <Skeleton className="h-48 w-full" />
+  if (!data) return null
+
+  return (
+    <section className="space-y-6">
+      <div>
+        <h1 className="text-2xl font-medium">Lead {data.orderID}</h1>
+        <p className="text-sm text-neutral-600 dark:text-neutral-400 -mt-1">Detalhes completos do lead</p>
+      </div>
+
+      <DescriptionList className="bg-white rounded-md border border-gray-100 p-6">
+        <DescriptionTerm>Status</DescriptionTerm>
+        <DescriptionDetails>{data.status}</DescriptionDetails>
+        <DescriptionTerm>Total</DescriptionTerm>
+        <DescriptionDetails>${data.total.toFixed(2)}</DescriptionDetails>
+        <DescriptionTerm>Product</DescriptionTerm>
+        <DescriptionDetails>{data.productType}</DescriptionDetails>
+        <DescriptionTerm>Address</DescriptionTerm>
+        <DescriptionDetails>{data.address.formatedAddress}</DescriptionDetails>
+      </DescriptionList>
+
+      {data.property?.[0]?.image && (
+        <img
+          src={data.property[0].image}
+          alt="Property"
+          className="rounded-md border border-gray-200"
+        />
+      )}
+    </section>
+  )
+}
+
+export default LeadDetailPage

--- a/src/app/plataform/leads/_components/LeadTable/index.tsx
+++ b/src/app/plataform/leads/_components/LeadTable/index.tsx
@@ -1,0 +1,50 @@
+'use client'
+
+// Dependencies
+import Link from 'next/link'
+import { EyeIcon } from 'lucide-react'
+
+// Types
+import type { Lead } from '@/services/leads/leads.props'
+
+interface LeadTableProps {
+  leads: Lead[]
+}
+
+const LeadTable = ({ leads }: LeadTableProps) => {
+  return (
+    <div className="overflow-auto rounded-lg border border-gray-200">
+      <table className="min-w-full divide-y divide-gray-100 bg-white table-auto">
+        <thead className="bg-gray-50 text-xs font-semibold text-gray-500 uppercase tracking-wide">
+          <tr>
+            <th className="px-6 py-4 text-left">Order</th>
+            <th className="px-6 py-4 text-left">Address</th>
+            <th className="px-6 py-4 text-left">Total</th>
+            <th className="px-6 py-4 text-right w-14">
+              <span className="sr-only">Actions</span>
+            </th>
+          </tr>
+        </thead>
+        <tbody className="divide-y divide-gray-100 text-sm text-gray-700">
+          {leads.map((lead) => (
+            <tr key={lead._id} className="hover:bg-gray-50 transition">
+              <td className="px-6 py-4">{lead.orderID}</td>
+              <td className="px-6 py-4">{lead.address.formatedAddress}</td>
+              <td className="px-6 py-4">${lead.total.toFixed(2)}</td>
+              <td className="px-6 py-4 text-right">
+                <Link
+                  href={`/plataform/leads/${lead._id}`}
+                  className="text-gray-500 hover:text-gray-900"
+                >
+                  <EyeIcon className="h-5 w-5" />
+                </Link>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  )
+}
+
+export default LeadTable

--- a/src/app/plataform/leads/_components/LeadTableSkeleton/index.tsx
+++ b/src/app/plataform/leads/_components/LeadTableSkeleton/index.tsx
@@ -1,0 +1,39 @@
+'use client'
+
+// Dependencies
+import Skeleton from '@/components/catalyst/skeleton'
+
+const ROWS = 10
+
+const LeadTableSkeleton = () => {
+  return (
+    <div className="overflow-auto rounded-lg border border-gray-200">
+      <table className="min-w-full divide-y divide-gray-100 bg-white table-auto">
+        <thead className="bg-gray-50 text-xs font-semibold text-gray-500 uppercase tracking-wide">
+          <tr>
+            <th className="px-6 py-4 text-left">Order</th>
+            <th className="px-6 py-4 text-left">Address</th>
+            <th className="px-6 py-4 text-left">Total</th>
+            <th className="px-6 py-4 text-right w-14">
+              <span className="sr-only">Actions</span>
+            </th>
+          </tr>
+        </thead>
+        <tbody className="divide-y divide-gray-100 text-sm text-gray-700">
+          {Array.from({ length: ROWS }).map((_, index) => (
+            <tr key={index} className="hover:bg-gray-50 transition">
+              <td className="px-6 py-4"><Skeleton className="h-4 w-20" /></td>
+              <td className="px-6 py-4"><Skeleton className="h-4 w-56" /></td>
+              <td className="px-6 py-4"><Skeleton className="h-4 w-16" /></td>
+              <td className="px-6 py-4 text-right">
+                <Skeleton className="h-5 w-5 ml-auto" />
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  )
+}
+
+export default LeadTableSkeleton

--- a/src/app/plataform/leads/page.tsx
+++ b/src/app/plataform/leads/page.tsx
@@ -1,0 +1,50 @@
+'use client'
+
+// Dependencies
+import { useState } from 'react'
+import { useQuery } from 'react-query'
+
+// Components
+import PaginationControls from '../users/_components/Pagination'
+import LeadTable from './_components/LeadTable'
+import LeadTableSkeleton from './_components/LeadTableSkeleton'
+
+// Services
+import { GetLeads } from '@/services/leads'
+
+// Types
+import type { GetLeadsResponse } from '@/services/leads/leads.props'
+
+const PageLeads = () => {
+  const [page, setPage] = useState(1)
+  const limit = 10
+
+  const { data, isFetching } = useQuery<GetLeadsResponse>({
+    queryKey: ['/leads', page],
+    queryFn: () => GetLeads({ page, limit }),
+    keepPreviousData: true,
+  })
+
+  return (
+    <section>
+      <div className="grid grid-cols-[1fr_auto] justify-between items-center mb-6 border-b border-gray-100 pb-4">
+        <div>
+          <h1 className="text-2xl font-medium">Leads</h1>
+          <p className="text-sm text-neutral-600 dark:text-neutral-400 -mt-1">Lista de oportunidades</p>
+        </div>
+      </div>
+
+      {isFetching ? (
+        <LeadTableSkeleton />
+      ) : (
+        <LeadTable leads={data?.data || []} />
+      )}
+
+      {data && data.totalPages > 1 && (
+        <PaginationControls page={page} totalPages={data.totalPages} onChange={setPage} />
+      )}
+    </section>
+  )
+}
+
+export default PageLeads

--- a/src/services/leads/index.ts
+++ b/src/services/leads/index.ts
@@ -1,0 +1,20 @@
+// Dependencies
+import { api } from '../api'
+
+// Types
+import type { GetLeadsFilters, GetLeadsResponse, Lead } from './leads.props'
+
+// Services
+const GetLeads = (filters?: GetLeadsFilters): Promise<GetLeadsResponse> => {
+  const params = new URLSearchParams()
+  params.append('items', '{}')
+  if (filters?.page) params.append('page', String(filters.page))
+  if (filters?.limit) params.append('limit', String(filters.limit))
+
+  return api(`/house_estimate?${params.toString()}`, { method: 'GET' })
+}
+
+const GetLead = (id: string): Promise<Lead> =>
+  api(`/house_estimate/${id}`, { method: 'GET' })
+
+export { GetLeads, GetLead }

--- a/src/services/leads/leads.props.ts
+++ b/src/services/leads/leads.props.ts
@@ -1,0 +1,67 @@
+export interface LeadAddress {
+  placeId: string
+  zipCode: string
+  addressLine1: string
+  addressLine2: string
+  country: string
+  shortCountry: string
+  state: string
+  shortState: string
+  city: string
+  shortCity: string
+  formatedAddress: string
+  latitude: number
+  longitude: number
+}
+
+export interface LeadProperty {
+  image?: string
+  origin?: string
+  description?: string
+  livingAreaValue?: number
+  propertyType?: string
+}
+
+export interface LeadItem {
+  id: number
+  idItem: number
+  label: string
+  title: string
+  value: string
+  multiple: number
+  valueAdicional: number
+  summaryLabel: string
+}
+
+export interface Lead {
+  _id: string
+  orderID: string
+  status: string
+  total: number
+  discount?: number
+  invoiceStatus?: string
+  address: LeadAddress
+  statusApprovedInvoice?: boolean
+  acceptSMS?: boolean
+  photos?: string[]
+  statusPayment?: string
+  suggestionSchedule?: unknown[]
+  property: LeadProperty[]
+  items: LeadItem[]
+  isHomeOwner?: boolean
+  productType?: string
+  roof?: string
+  roofColor?: string
+  step?: string
+}
+
+export interface GetLeadsFilters {
+  page?: number
+  limit?: number
+}
+
+export interface GetLeadsResponse {
+  data: Lead[]
+  page: number
+  totalPages: number
+}


### PR DESCRIPTION
## Summary
- implement leads service
- show leads table with pagination
- add lead details page

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68883a1218f883258b35b27934822665