### PR TITLE
Enhance lead views with badges

### DIFF
--- a/src/app/plataform/leads/[id]/page.tsx
+++ b/src/app/plataform/leads/[id]/page.tsx
@@ -7,6 +7,8 @@ import { useQuery } from 'react-query'
 // Components
 import Skeleton from '@/components/catalyst/skeleton'
 import { DescriptionList, DescriptionTerm, DescriptionDetails } from '@/components/catalyst/description-list'
+import { Badge } from '@/components/catalyst/badge'
+import { Subheading } from '@/components/catalyst/heading'
 
 // Services
 import { GetLead } from '@/services/leads'
@@ -24,22 +26,123 @@ const LeadDetailPage = () => {
   if (!data) return null
 
   return (
-    <section className="space-y-6">
+    <section className="space-y-8">
       <div>
         <h1 className="text-2xl font-medium">Lead {data.orderID}</h1>
         <p className="text-sm text-neutral-600 dark:text-neutral-400 -mt-1">Detalhes completos do lead</p>
       </div>
 
-      <DescriptionList className="bg-white rounded-md border border-gray-100 p-6">
-        <DescriptionTerm>Status</DescriptionTerm>
-        <DescriptionDetails>{data.status}</DescriptionDetails>
-        <DescriptionTerm>Total</DescriptionTerm>
-        <DescriptionDetails>${data.total.toFixed(2)}</DescriptionDetails>
-        <DescriptionTerm>Product</DescriptionTerm>
-        <DescriptionDetails>{data.productType}</DescriptionDetails>
-        <DescriptionTerm>Address</DescriptionTerm>
-        <DescriptionDetails>{data.address.formatedAddress}</DescriptionDetails>
-      </DescriptionList>
+      <div className="space-y-6">
+        <div className="space-y-3">
+          <Subheading>General</Subheading>
+          <DescriptionList className="bg-white rounded-md border border-gray-100 p-6">
+            <DescriptionTerm>Status</DescriptionTerm>
+            <DescriptionDetails>
+              <Badge color="blue">{data.status}</Badge>
+            </DescriptionDetails>
+            {data.productType && (
+              <>
+                <DescriptionTerm>Product</DescriptionTerm>
+                <DescriptionDetails>{data.productType}</DescriptionDetails>
+              </>
+            )}
+            {data.step && (
+              <>
+                <DescriptionTerm>Step</DescriptionTerm>
+                <DescriptionDetails>{data.step}</DescriptionDetails>
+              </>
+            )}
+          </DescriptionList>
+        </div>
+
+        <div className="space-y-3">
+          <Subheading>Financial</Subheading>
+          <DescriptionList className="bg-white rounded-md border border-gray-100 p-6">
+            {data.initialValue !== undefined && (
+              <>
+                <DescriptionTerm>Initial Value</DescriptionTerm>
+                <DescriptionDetails>{data.initialValue.toFixed(2)}</DescriptionDetails>
+              </>
+            )}
+            <DescriptionTerm>Total</DescriptionTerm>
+            <DescriptionDetails>${data.total.toFixed(2)}</DescriptionDetails>
+            {data.discount !== undefined && (
+              <>
+                <DescriptionTerm>Discount</DescriptionTerm>
+                <DescriptionDetails>{data.discount.toFixed(2)}</DescriptionDetails>
+              </>
+            )}
+          </DescriptionList>
+        </div>
+
+        {(data.name || data.email || data.phone) && (
+          <div className="space-y-3">
+            <Subheading>Contact</Subheading>
+            <DescriptionList className="bg-white rounded-md border border-gray-100 p-6">
+              {data.name && (
+                <>
+                  <DescriptionTerm>Name</DescriptionTerm>
+                  <DescriptionDetails>{data.name}</DescriptionDetails>
+                </>
+              )}
+              {data.email && (
+                <>
+                  <DescriptionTerm>Email</DescriptionTerm>
+                  <DescriptionDetails>{data.email}</DescriptionDetails>
+                </>
+              )}
+              {data.phone && (
+                <>
+                  <DescriptionTerm>Phone</DescriptionTerm>
+                  <DescriptionDetails>{data.phone}</DescriptionDetails>
+                </>
+              )}
+            </DescriptionList>
+          </div>
+        )}
+
+        <div className="space-y-3">
+          <Subheading>Billing</Subheading>
+          <DescriptionList className="bg-white rounded-md border border-gray-100 p-6">
+            {data.invoiceStatus && (
+              <>
+                <DescriptionTerm>Invoice Status</DescriptionTerm>
+                <DescriptionDetails>{data.invoiceStatus}</DescriptionDetails>
+              </>
+            )}
+            {data.statusPayment && (
+              <>
+                <DescriptionTerm>Status Payment</DescriptionTerm>
+                <DescriptionDetails>{data.statusPayment}</DescriptionDetails>
+              </>
+            )}
+            {data.invoiceStartDate && (
+              <>
+                <DescriptionTerm>Invoice Start Date</DescriptionTerm>
+                <DescriptionDetails>
+                  {new Date(data.invoiceStartDate).toLocaleDateString()}
+                </DescriptionDetails>
+              </>
+            )}
+            {data.invoiceDueDate && (
+              <>
+                <DescriptionTerm>Invoice Due Date</DescriptionTerm>
+                <DescriptionDetails>
+                  {new Date(data.invoiceDueDate).toLocaleDateString()}
+                </DescriptionDetails>
+              </>
+            )}
+          </DescriptionList>
+        </div>
+
+        <div className="space-y-3">
+          <Subheading>Address</Subheading>
+          <DescriptionList className="bg-white rounded-md border border-gray-100 p-6">
+            <DescriptionTerm>Formatted</DescriptionTerm>
+            <DescriptionDetails>{data.address.formatedAddress}</DescriptionDetails>
+          </DescriptionList>
+        </div>
+      </div>
 
       {data.property?.[0]?.image && (
         <img
@@ -48,6 +151,13 @@ const LeadDetailPage = () => {
           className="rounded-md border border-gray-200"
         />
       )}
+
+      <iframe
+        title="map"
+        src={`https://maps.google.com/maps?q=${data.address.latitude},${data.address.longitude}&z=15&output=embed`}
+        className="w-full h-60 rounded-md border border-gray-200"
+        loading="lazy"
+      />
     </section>
   )
 }

--- a/src/app/plataform/leads/_components/LeadTable/index.tsx
+++ b/src/app/plataform/leads/_components/LeadTable/index.tsx
@@ -4,6 +4,9 @@
 import Link from 'next/link'
 import { EyeIcon } from 'lucide-react'
 
+// Components
+import { Badge } from '@/components/catalyst/badge'
+
 // Types
 import type { Lead } from '@/services/leads/leads.props'
 
@@ -18,8 +21,10 @@ const LeadTable = ({ leads }: LeadTableProps) => {
         <thead className="bg-gray-50 text-xs font-semibold text-gray-500 uppercase tracking-wide">
           <tr>
             <th className="px-6 py-4 text-left">Order</th>
+            <th className="px-6 py-4 text-left">Product</th>
             <th className="px-6 py-4 text-left">Address</th>
             <th className="px-6 py-4 text-left">Total</th>
+            <th className="px-6 py-4 text-left">Status</th>
             <th className="px-6 py-4 text-right w-14">
               <span className="sr-only">Actions</span>
             </th>
@@ -29,8 +34,14 @@ const LeadTable = ({ leads }: LeadTableProps) => {
           {leads.map((lead) => (
             <tr key={lead._id} className="hover:bg-gray-50 transition">
               <td className="px-6 py-4">{lead.orderID}</td>
+              <td className="px-6 py-4">{lead.productType || '-'}</td>
               <td className="px-6 py-4">{lead.address.formatedAddress}</td>
               <td className="px-6 py-4">${lead.total.toFixed(2)}</td>
+              <td className="px-6 py-4">
+                <Badge color={lead.name && lead.email && lead.phone ? 'green' : 'red'}>
+                  {lead.name && lead.email && lead.phone ? 'Completed' : 'Incomplete'}
+                </Badge>
+              </td>
               <td className="px-6 py-4 text-right">
                 <Link
                   href={`/plataform/leads/${lead._id}`}

--- a/src/app/plataform/leads/_components/LeadTableSkeleton/index.tsx
+++ b/src/app/plataform/leads/_components/LeadTableSkeleton/index.tsx
@@ -12,8 +12,10 @@ const LeadTableSkeleton = () => {
         <thead className="bg-gray-50 text-xs font-semibold text-gray-500 uppercase tracking-wide">
           <tr>
             <th className="px-6 py-4 text-left">Order</th>
+            <th className="px-6 py-4 text-left">Product</th>
             <th className="px-6 py-4 text-left">Address</th>
             <th className="px-6 py-4 text-left">Total</th>
+            <th className="px-6 py-4 text-left">Status</th>
             <th className="px-6 py-4 text-right w-14">
               <span className="sr-only">Actions</span>
             </th>
@@ -23,8 +25,10 @@ const LeadTableSkeleton = () => {
           {Array.from({ length: ROWS }).map((_, index) => (
             <tr key={index} className="hover:bg-gray-50 transition">
               <td className="px-6 py-4"><Skeleton className="h-4 w-20" /></td>
+              <td className="px-6 py-4"><Skeleton className="h-4 w-28" /></td>
               <td className="px-6 py-4"><Skeleton className="h-4 w-56" /></td>
               <td className="px-6 py-4"><Skeleton className="h-4 w-16" /></td>
+              <td className="px-6 py-4"><Skeleton className="h-5 w-24" /></td>
               <td className="px-6 py-4 text-right">
                 <Skeleton className="h-5 w-5 ml-auto" />
               </td>

--- a/src/services/leads/leads.props.ts
+++ b/src/services/leads/leads.props.ts
@@ -37,6 +37,7 @@ export interface Lead {
   _id: string
   orderID: string
   status: string
+  initialValue?: number
   total: number
   discount?: number
   invoiceStatus?: string
@@ -48,11 +49,21 @@ export interface Lead {
   suggestionSchedule?: unknown[]
   property: LeadProperty[]
   items: LeadItem[]
+  /** Personal information */
+  name?: string
+  email?: string
+  phone?: string
   isHomeOwner?: boolean
   productType?: string
   roof?: string
   roofColor?: string
   step?: string
+  /** Billing info */
+  fileInvoice?: string
+  idPayment?: string
+  invoiceDueDate?: string
+  invoiceStartDate?: string
+  urlPayment?: string
 }
 
 export interface GetLeadsFilters {


### PR DESCRIPTION
## Summary
- add status badge to lead list
- polish skeleton for new badge
- restructure lead detail into sections with subheadings
- display status with a badge

## Testing
- `npm run lint` *(fails: next not found)*
- `npm ci` *(fails: network access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_688913635ad8832596b33072f726b7df