### PR TITLE
Add Sales table with skeleton

### DIFF
--- a/src/app/plataform/sales/_components/SalesTable/index.tsx
+++ b/src/app/plataform/sales/_components/SalesTable/index.tsx
@@ -1,0 +1,57 @@
+'use client'
+
+// Dependencies
+import Link from 'next/link'
+import { PencilIcon, Trash2Icon } from 'lucide-react'
+
+// Types
+import type { Sale } from '@/services/sales/sales.props'
+
+interface SalesTableProps {
+  sales: Sale[]
+}
+
+const SalesTable = ({ sales }: SalesTableProps) => {
+  return (
+    <div className="overflow-auto rounded-lg border border-gray-200">
+      <table className="min-w-full divide-y divide-gray-100 bg-white">
+        <thead className="bg-gray-50 text-xs font-semibold text-gray-500 uppercase tracking-wide">
+          <tr>
+            <th className="px-6 py-4 text-left">Address</th>
+            <th className="px-6 py-4 text-left">Responsible</th>
+            <th className="px-6 py-4 text-left">Phone</th>
+            <th className="px-6 py-4 text-left">Lat</th>
+            <th className="px-6 py-4 text-left">Long</th>
+            <th className="px-6 py-4 text-right w-20">
+              <span className="sr-only">Actions</span>
+            </th>
+          </tr>
+        </thead>
+        <tbody className="divide-y divide-gray-100 text-sm text-gray-700">
+          {sales.map((sale) => (
+            <tr key={sale.id} className="hover:bg-gray-50 transition">
+              <td className="px-6 py-4">{sale.address}</td>
+              <td className="px-6 py-4">{sale.responsibleName}</td>
+              <td className="px-6 py-4">{sale.phone || '-'}</td>
+              <td className="px-6 py-4">{sale.lat}</td>
+              <td className="px-6 py-4">{sale.long}</td>
+              <td className="px-6 py-4 text-right flex justify-end gap-2">
+                <Link
+                  href={`/plataform/sales/${sale.id}/edit`}
+                  className="text-gray-500 hover:text-gray-900"
+                >
+                  <PencilIcon className="h-5 w-5" />
+                </Link>
+                <button className="text-gray-500 hover:text-red-600">
+                  <Trash2Icon className="h-5 w-5" />
+                </button>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  )
+}
+
+export default SalesTable

--- a/src/app/plataform/sales/_components/SalesTableSkeleton/index.tsx
+++ b/src/app/plataform/sales/_components/SalesTableSkeleton/index.tsx
@@ -1,0 +1,42 @@
+'use client'
+
+// Dependencies
+import Skeleton from '@/components/catalyst/skeleton'
+
+const ROWS = 10
+
+const SalesTableSkeleton = () => (
+  <div className="overflow-auto rounded-lg border border-gray-200">
+    <table className="min-w-full divide-y divide-gray-100 bg-white">
+      <thead className="bg-gray-50 text-xs font-semibold text-gray-500 uppercase tracking-wide">
+        <tr>
+          <th className="px-6 py-4 text-left">Address</th>
+          <th className="px-6 py-4 text-left">Responsible</th>
+          <th className="px-6 py-4 text-left">Phone</th>
+          <th className="px-6 py-4 text-left">Lat</th>
+          <th className="px-6 py-4 text-left">Long</th>
+          <th className="px-6 py-4 text-right w-20">
+            <span className="sr-only">Actions</span>
+          </th>
+        </tr>
+      </thead>
+      <tbody className="divide-y divide-gray-100 text-sm text-gray-700">
+        {Array.from({ length: ROWS }).map((_, index) => (
+          <tr key={index} className="hover:bg-gray-50 transition">
+            <td className="px-6 py-4"><Skeleton className="h-4 w-40" /></td>
+            <td className="px-6 py-4"><Skeleton className="h-4 w-24" /></td>
+            <td className="px-6 py-4"><Skeleton className="h-4 w-24" /></td>
+            <td className="px-6 py-4"><Skeleton className="h-4 w-16" /></td>
+            <td className="px-6 py-4"><Skeleton className="h-4 w-16" /></td>
+            <td className="px-6 py-4 text-right flex justify-end gap-2">
+              <Skeleton className="h-5 w-5" />
+              <Skeleton className="h-5 w-5" />
+            </td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  </div>
+)
+
+export default SalesTableSkeleton

--- a/src/app/plataform/sales/page.tsx
+++ b/src/app/plataform/sales/page.tsx
@@ -1,0 +1,50 @@
+'use client'
+
+// Dependencies
+import { useState } from 'react'
+import { useQuery } from 'react-query'
+
+// Components
+import PaginationControls from '../users/_components/Pagination'
+import SalesTable from './_components/SalesTable'
+import SalesTableSkeleton from './_components/SalesTableSkeleton'
+
+// Services
+import { GetSales } from '@/services/sales'
+
+// Types
+import type { GetSalesResponse } from '@/services/sales/sales.props'
+
+const PageSales = () => {
+  const [page, setPage] = useState(1)
+  const limit = 10
+
+  const { data, isFetching } = useQuery<GetSalesResponse>({
+    queryKey: ['/sales', page],
+    queryFn: () => GetSales({ page, limit }),
+    keepPreviousData: true,
+  })
+
+  return (
+    <section>
+      <div className="grid grid-cols-[1fr_auto] justify-between items-center mb-6 border-b border-gray-100 pb-4">
+        <div>
+          <h1 className="text-2xl font-medium">Sales</h1>
+          <p className="text-sm text-neutral-600 dark:text-neutral-400 -mt-1">Listagem de vendas</p>
+        </div>
+      </div>
+
+      {isFetching ? (
+        <SalesTableSkeleton />
+      ) : (
+        <SalesTable sales={data?.data || []} />
+      )}
+
+      {data && data.totalPages > 1 && (
+        <PaginationControls page={page} totalPages={data.totalPages} onChange={setPage} />
+      )}
+    </section>
+  )
+}
+
+export default PageSales

--- a/src/services/sales/index.ts
+++ b/src/services/sales/index.ts
@@ -1,0 +1,26 @@
+// Dependencies
+import { api } from '../api'
+
+// Types
+import type { GetSalesFilters, GetSalesResponse, Sale } from './sales.props'
+
+// Services
+const GetSales = (filters?: GetSalesFilters): Promise<GetSalesResponse> => {
+  const params = new URLSearchParams()
+  if (filters?.address) params.append('address', filters.address)
+  if (typeof filters?.lat === 'number') params.append('lat', String(filters.lat))
+  if (typeof filters?.long === 'number') params.append('long', String(filters.long))
+  if (filters?.responsibleName) params.append('responsibleName', filters.responsibleName)
+  if (filters?.phone) params.append('phone', filters.phone)
+  if (filters?.page) params.append('page', String(filters.page))
+  if (filters?.limit) params.append('limit', String(filters.limit))
+
+  const query = params.size ? `?${params.toString()}` : ''
+
+  return api(`/sales${query}`, { method: 'GET' })
+}
+
+const GetSale = (id: string): Promise<Sale> =>
+  api(`/sales/${id}`, { method: 'GET' })
+
+export { GetSales, GetSale }

--- a/src/services/sales/sales.props.ts
+++ b/src/services/sales/sales.props.ts
@@ -1,0 +1,24 @@
+export interface Sale {
+  id: string
+  address: string
+  lat: number
+  long: number
+  responsibleName: string
+  phone?: string
+}
+
+export interface GetSalesFilters {
+  address?: string
+  lat?: number
+  long?: number
+  responsibleName?: string
+  phone?: string
+  page?: number
+  limit?: number
+}
+
+export interface GetSalesResponse {
+  data: Sale[]
+  page: number
+  totalPages: number
+}


### PR DESCRIPTION
## Summary
- implement sales service
- create sales listing page with pagination
- add table and skeleton components for sales data

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68891fac6ed88325915b738ce18f7ae5