### PR TITLE
Add Sales drawer with form

### DIFF
--- a/src/app/plataform/sales/_components/SaleForm/form.types.ts
+++ b/src/app/plataform/sales/_components/SaleForm/form.types.ts
@@ -1,0 +1,11 @@
+export interface SaleFormValues {
+  address: string
+  lat?: number
+  long?: number
+  responsibleName: string
+  phone?: string
+}
+
+export interface SaleFormProps {
+  onSuccess?: () => void
+}

--- a/src/app/plataform/sales/_components/SaleForm/index.tsx
+++ b/src/app/plataform/sales/_components/SaleForm/index.tsx
@@ -1,0 +1,83 @@
+'use client'
+
+// Dependencies
+import { useForm } from 'react-hook-form'
+import { zodResolver } from '@hookform/resolvers/zod'
+import { useMutation } from 'react-query'
+
+// Components
+import InputComponent from '@/components/Form/Input/InputComponent'
+import Button from '@/components/Form/Button'
+
+// Services
+import { CreateSale } from '@/services/sales'
+import { GeocodeAddress } from '@/services/geocode'
+
+// Context
+import { useNotification } from '@/context/notification'
+
+// Types
+import type { SaleFormProps, SaleFormValues } from './form.types'
+import SaleSchema from './schema'
+
+const SaleForm = ({ onSuccess }: SaleFormProps) => {
+  const { control, handleSubmit, setValue } = useForm<SaleFormValues>({
+    resolver: zodResolver(SaleSchema),
+    defaultValues: {
+      address: '',
+      responsibleName: '',
+      phone: '',
+    },
+  })
+
+  const { showNotification } = useNotification()
+
+  const mutation = useMutation(CreateSale, {
+    onSuccess: () => {
+      showNotification('Sale created', 'success')
+      onSuccess?.()
+    },
+    onError: () => {
+      showNotification('Failed to create sale', 'error')
+    },
+  })
+
+  const handleAddressBlur = async (value: string) => {
+    const coords = await GeocodeAddress(value)
+    if (coords) {
+      setValue('lat', coords.lat)
+      setValue('long', coords.long)
+    }
+  }
+
+  return (
+    <form onSubmit={handleSubmit((data) => mutation.mutate(data))} className="space-y-4 max-w-sm">
+      <InputComponent
+        label="Address"
+        name="address"
+        control={control}
+        required
+        handleBlur={handleAddressBlur}
+        inputType="default"
+        type="text"
+      />
+      <InputComponent
+        label="Responsible name"
+        name="responsibleName"
+        control={control}
+        required
+        inputType="default"
+        type="text"
+      />
+      <InputComponent
+        label="Phone"
+        name="phone"
+        control={control}
+        inputType="mask"
+      />
+      <Button label="Save" type="submit" variant="primary" loading={mutation.isLoading} />
+    </form>
+  )
+}
+
+export default SaleForm

--- a/src/app/plataform/sales/_components/SaleForm/schema.ts
+++ b/src/app/plataform/sales/_components/SaleForm/schema.ts
@@ -1,0 +1,11 @@
+import * as z from 'zod'
+
+const SaleSchema = z.object({
+  address: z.string().min(1, { message: 'Required' }),
+  lat: z.number().optional(),
+  long: z.number().optional(),
+  responsibleName: z.string().min(1, { message: 'Required' }),
+  phone: z.string().optional(),
+})
+
+export default SaleSchema

--- a/src/app/plataform/sales/_components/SalesTable/index.tsx
+++ b/src/app/plataform/sales/_components/SalesTable/index.tsx
@@ -1,0 +1,51 @@
+'use client'
+
+// Dependencies
+import Link from 'next/link'
+import { PencilIcon, Trash2Icon } from 'lucide-react'
+
+// Types
+import type { Sale } from '@/services/sales/sales.props'
+
+interface SalesTableProps {
+  sales: Sale[]
+}
+
+const SalesTable = ({ sales }: SalesTableProps) => {
+  return (
+    <div className="overflow-auto rounded-lg border border-gray-200">
+      <table className="min-w-full divide-y divide-gray-100 bg-white">
+        <thead className="bg-gray-50 text-xs font-semibold text-gray-500 uppercase tracking-wide">
+          <tr>
+          <th className="px-6 py-4 text-left">Address</th>
+          <th className="px-6 py-4 text-left">Responsible</th>
+          <th className="px-6 py-4 text-right w-20">
+            <span className="sr-only">Actions</span>
+          </th>
+          </tr>
+        </thead>
+        <tbody className="divide-y divide-gray-100 text-sm text-gray-700">
+          {sales.map((sale) => (
+            <tr key={sale.id} className="hover:bg-gray-50 transition">
+              <td className="px-6 py-4">{sale.address}</td>
+              <td className="px-6 py-4">{sale.responsibleName}</td>
+              <td className="px-6 py-4 text-right flex justify-end gap-2">
+                <Link
+                  href={`/plataform/sales/${sale.id}/edit`}
+                  className="text-gray-500 hover:text-gray-900"
+                >
+                  <PencilIcon className="h-5 w-5" />
+                </Link>
+                <button className="text-gray-500 hover:text-red-600">
+                  <Trash2Icon className="h-5 w-5" />
+                </button>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  )
+}
+
+export default SalesTable

--- a/src/app/plataform/sales/_components/SalesTableSkeleton/index.tsx
+++ b/src/app/plataform/sales/_components/SalesTableSkeleton/index.tsx
@@ -1,0 +1,36 @@
+'use client'
+
+// Dependencies
+import Skeleton from '@/components/catalyst/skeleton'
+
+const ROWS = 10
+
+const SalesTableSkeleton = () => (
+  <div className="overflow-auto rounded-lg border border-gray-200">
+    <table className="min-w-full divide-y divide-gray-100 bg-white">
+      <thead className="bg-gray-50 text-xs font-semibold text-gray-500 uppercase tracking-wide">
+        <tr>
+          <th className="px-6 py-4 text-left">Address</th>
+          <th className="px-6 py-4 text-left">Responsible</th>
+          <th className="px-6 py-4 text-right w-20">
+            <span className="sr-only">Actions</span>
+          </th>
+        </tr>
+      </thead>
+      <tbody className="divide-y divide-gray-100 text-sm text-gray-700">
+        {Array.from({ length: ROWS }).map((_, index) => (
+          <tr key={index} className="hover:bg-gray-50 transition">
+            <td className="px-6 py-4"><Skeleton className="h-4 w-40" /></td>
+            <td className="px-6 py-4"><Skeleton className="h-4 w-24" /></td>
+            <td className="px-6 py-4 text-right flex justify-end gap-2">
+              <Skeleton className="h-5 w-5" />
+              <Skeleton className="h-5 w-5" />
+            </td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  </div>
+)
+
+export default SalesTableSkeleton

--- a/src/app/plataform/sales/page.tsx
+++ b/src/app/plataform/sales/page.tsx
@@ -1,0 +1,67 @@
+'use client'
+
+// Dependencies
+import { useState } from 'react'
+import { useQuery } from 'react-query'
+import { PlusIcon } from 'lucide-react'
+
+// Components
+import PaginationControls from '../users/_components/Pagination'
+import SalesTable from './_components/SalesTable'
+import SalesTableSkeleton from './_components/SalesTableSkeleton'
+import SaleForm from './_components/SaleForm'
+import Drawer from '@/components/catalyst/drawer'
+import Button from '@/components/Form/Button'
+
+// Services
+import { GetSales } from '@/services/sales'
+
+// Types
+import type { GetSalesResponse } from '@/services/sales/sales.props'
+
+const PageSales = () => {
+  const [page, setPage] = useState(1)
+  const [open, setOpen] = useState(false)
+  const limit = 10
+
+  const { data, isFetching, refetch } = useQuery<GetSalesResponse>({
+    queryKey: ['/sales', page],
+    queryFn: () => GetSales({ page, limit }),
+    keepPreviousData: true,
+  })
+
+  return (
+    <section>
+      <div className="grid grid-cols-[1fr_auto] justify-between items-center mb-6 border-b border-gray-100 pb-4">
+        <div>
+          <h1 className="text-2xl font-medium">Sales</h1>
+          <p className="text-sm text-neutral-600 dark:text-neutral-400 -mt-1">Listagem de vendas</p>
+        </div>
+        <Button
+          label="New"
+          variant="primary"
+          size="medium"
+          icon={<PlusIcon className="w-4" />}
+          onClick={() => setOpen(true)}
+        />
+      </div>
+
+      {isFetching ? (
+        <SalesTableSkeleton />
+      ) : (
+        <SalesTable sales={data?.data || []} />
+      )}
+
+      {data && data.totalPages > 1 && (
+        <PaginationControls page={page} totalPages={data.totalPages} onChange={setPage} />
+      )}
+
+      <Drawer open={open} onClose={() => setOpen(false)}>
+        <h2 className="text-lg font-medium mb-4">New Sale</h2>
+        <SaleForm onSuccess={() => { setOpen(false); refetch() }} />
+      </Drawer>
+    </section>
+  )
+}
+
+export default PageSales

--- a/src/components/catalyst/drawer.tsx
+++ b/src/components/catalyst/drawer.tsx
@@ -1,0 +1,26 @@
+'use client'
+
+// Dependencies
+import * as Headless from '@headlessui/react'
+import clsx from 'clsx'
+import type { ReactNode } from 'react'
+
+interface DrawerProps {
+  open: boolean
+  onClose: () => void
+  className?: string
+  children: ReactNode
+}
+
+const Drawer = ({ open, onClose, className, children }: DrawerProps) => (
+  <Headless.Dialog open={open} onClose={onClose} className="fixed inset-0 z-50 flex">
+    <Headless.DialogBackdrop className="fixed inset-0 bg-black/30" />
+    <div className="ml-auto h-full w-full max-w-md transform transition-transform duration-300">
+      <Headless.DialogPanel className={clsx('h-full overflow-y-auto bg-white p-6 shadow-xl', className)}>
+        {children}
+      </Headless.DialogPanel>
+    </div>
+  </Headless.Dialog>
+)
+
+export default Drawer

--- a/src/services/geocode/index.ts
+++ b/src/services/geocode/index.ts
@@ -1,0 +1,21 @@
+// Dependencies
+export interface Coordinates {
+  lat: number
+  long: number
+}
+
+const GeocodeAddress = async (address: string): Promise<Coordinates | null> => {
+  const url = `https://nominatim.openstreetmap.org/search?format=json&limit=1&q=${encodeURIComponent(address)}`
+  try {
+    const response = await fetch(url)
+    const data = await response.json()
+    if (data && data.length > 0) {
+      return { lat: parseFloat(data[0].lat), long: parseFloat(data[0].lon) }
+    }
+    return null
+  } catch {
+    return null
+  }
+}
+
+export { GeocodeAddress }

--- a/src/services/sales/index.ts
+++ b/src/services/sales/index.ts
@@ -1,0 +1,29 @@
+// Dependencies
+import { api } from '../api'
+
+// Types
+import type { GetSalesFilters, GetSalesResponse, Sale, SaleDTO } from './sales.props'
+
+// Services
+const GetSales = (filters?: GetSalesFilters): Promise<GetSalesResponse> => {
+  const params = new URLSearchParams()
+  if (filters?.address) params.append('address', filters.address)
+  if (typeof filters?.lat === 'number') params.append('lat', String(filters.lat))
+  if (typeof filters?.long === 'number') params.append('long', String(filters.long))
+  if (filters?.responsibleName) params.append('responsibleName', filters.responsibleName)
+  if (filters?.phone) params.append('phone', filters.phone)
+  if (filters?.page) params.append('page', String(filters.page))
+  if (filters?.limit) params.append('limit', String(filters.limit))
+
+  const query = params.size ? `?${params.toString()}` : ''
+
+  return api(`/sales${query}`, { method: 'GET' })
+}
+
+const GetSale = (id: string): Promise<Sale> =>
+  api(`/sales/${id}`, { method: 'GET' })
+
+const CreateSale = (data: SaleDTO): Promise<Sale> =>
+  api('/sales', { method: 'POST', body: data })
+
+export { GetSales, GetSale, CreateSale }

--- a/src/services/sales/sales.props.ts
+++ b/src/services/sales/sales.props.ts
@@ -1,0 +1,32 @@
+export interface Sale {
+  id: string
+  address: string
+  lat: number
+  long: number
+  responsibleName: string
+  phone?: string
+}
+
+export interface SaleDTO {
+  address: string
+  lat?: number
+  long?: number
+  responsibleName: string
+  phone?: string
+}
+
+export interface GetSalesFilters {
+  address?: string
+  lat?: number
+  long?: number
+  responsibleName?: string
+  phone?: string
+  page?: number
+  limit?: number
+}
+
+export interface GetSalesResponse {
+  data: Sale[]
+  page: number
+  totalPages: number
+}


### PR DESCRIPTION
## Summary
- add drawer component
- implement geocode service
- create SaleForm with address autocomplete
- expose CreateSale service method
- update sales page with drawer and button
- show only address and responsible name in sales table

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68891fac6ed88325915b738ce18f7ae5